### PR TITLE
Add `inject` function for manipulating `entry`.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,0 +1,5 @@
+import partial from './partial';
+import inject from './inject';
+
+export { partial, inject };
+export default partial;

--- a/lib/inject.js
+++ b/lib/inject.js
@@ -1,0 +1,14 @@
+export default function inject(entries, module) {
+  if (typeof entries === 'string') {
+    return [ ...module, entries ];
+  } else if (Array.isArray(entries)) {
+    return [ ...module, ...entries ];
+  } else if (typeof entries === 'object') {
+    const res = { };
+    for (const key of Object.keys(entries)) {
+      res[key] = inject(entries[key], module);
+    }
+    return res;
+  }
+  throw new TypeError();
+}

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 	"author": "Izaak Schroeder <izaak.schroeder@gmail.com>",
 	"description": "Webpack partials.",
 	"license": "CC0-1.0",
-	"main": "dist/lib/partial.js",
+	"main": "dist/lib/index.js",
 	"scripts": {
 		"prepublish:lib": "./node_modules/.bin/babel -d dist/lib lib",
 		"prepublish:test": "./node_modules/.bin/babel -d dist/test test",

--- a/test/spec/inject.spec.js
+++ b/test/spec/inject.spec.js
@@ -1,0 +1,21 @@
+import { expect } from 'chai';
+import inject from '../../lib/inject';
+
+describe('inject', () => {
+  it('should handle strings', () => {
+    expect(inject('index.js', [ 'a', 'b' ])).to.have.length(3);
+  });
+
+  it('should handle arrays', () => {
+    expect(inject(['index.js'], [ 'a', 'b' ])).to.have.length(3);
+  });
+
+  it('should handle objects', () => {
+    expect(inject({ a: 'index.js' }, [ 'a', 'b' ]))
+      .to.have.property('a').to.have.length(3);
+  });
+
+  it('should fail otherwise', () => {
+    expect(() => inject(false)).to.throw(TypeError);
+  });
+});


### PR DESCRIPTION
Sometimes you wish to add new scripts to an existing configurations `entry` property; `inject` lets you do just that. Since `partial` replaces `entry`, this function can be used to in conjunction to add elements.