### PR TITLE
Fix identical values being re-merged.

### DIFF
--- a/lib/partial.js
+++ b/lib/partial.js
@@ -27,11 +27,14 @@ export const inherit = (...args) => {
   return merge(
     ...args,
     (dst, src, key, object, source) => {
+      // Short-circuit same-assigns that have already been merged.
       // Treat entry specially since order is important we can't go just
       // randomly appending things.
       // Treat arrays with objects that have the `name` property specially;
       // entries with identical names will be merged.
-      if (key === 'entry' && src === source.entry) {
+      if (dst === src) {
+        return dst;
+      } else if (key === 'entry' && src === source.entry) {
         return entry(dst, src);
       } else if (isArray(dst) && isArray(src)) {
         return reduce(groupBy(dst.concat(src), name), (items, group, name) => {


### PR DESCRIPTION
Look at the simple case of merging:

```javascript
{ }
{ foo: { bar: [ 3 ] } }
```

First the `foo` property will be looked at – because it doesn't exist in the parent object it will be set in the parent object. So now the parent object looks exactly the same as the child. However, the merge is not done; the other properties must be considered. So this results in `bar` being merged with the other copy of `bar` and so forth. Because this is not actually what we want (and because it introduces interesting side effects with arrays) there is now a short-circuit check to prevent identical objects from being merged.