### PR TITLE
Add `tap` helper.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,6 @@
 import partial from './partial';
 import inject from './inject';
+import tap from './tap';
 
-export {partial, inject};
+export {partial, inject, tap};
 export default partial;

--- a/lib/tap.js
+++ b/lib/tap.js
@@ -1,0 +1,3 @@
+import curry from 'lodash/curry';
+
+export default curry((tap, config) => (tap(config), config));

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "lint": "./node_modules/.bin/eslint --ignore-path .gitignore .",
     "prepublish": "./node_modules/.bin/babel -s -d dist/lib lib",
-    "spec": "NODE_ENV=test ./node_modules/.bin/mocha --compilers js:babel-core/register -r adana-dump -R spec test/spec",
+    "spec": "NODE_ENV=test ./node_modules/.bin/mocha --compilers js:babel-core/register -r test/helper/chai -r adana-dump -R spec test/spec",
     "test": "npm run lint && npm run spec"
   },
   "repository": {
@@ -33,12 +33,14 @@
     "babel-cli": "^6.4.5",
     "babel-core": "^6.4.5",
     "babel-preset-metalab": "^0.2.0",
+    "chai": "^3.2.0",
     "eslint": "^1.10.3",
     "eslint-config-metalab": "^2.0.0-beta.1",
     "eslint-plugin-filenames": "^0.2.0",
     "eslint-plugin-import": "^0.12.1",
     "eslint-plugin-react": "^3.16.0",
     "mocha": "^2.3.4",
-    "chai": "^3.2.0"
+    "sinon": "^1.17.4",
+    "sinon-chai": "^2.8.0"
   }
 }

--- a/test/helper/chai.js
+++ b/test/helper/chai.js
@@ -1,0 +1,4 @@
+import chai from 'chai';
+import sinon from 'sinon-chai';
+
+chai.use(sinon);

--- a/test/spec/tap.spec.js
+++ b/test/spec/tap.spec.js
@@ -1,0 +1,16 @@
+import {expect} from 'chai';
+import sinon from 'sinon';
+import tap from '../../lib/tap';
+
+describe('tap', () => {
+  it('should return the original config', () => {
+    const conf = {message: 'hello'};
+    expect(tap(() => false, conf)).to.equal(conf);
+  });
+
+  it('should call the given function', () => {
+    const stub = sinon.stub();
+    tap(stub, 'test');
+    expect(stub).to.be.calledWith('test');
+  });
+});


### PR DESCRIPTION
There are several webpack utilities that operate on core webpack structures currently exist as external modules – saving people from more dependency hell, utilities which are small and have no dependencies will now be included in `webpack-partial`. This one ports the functionality from `webpack-config-tap`.

/cc @baer @nealgranger 