### PR TITLE
Add `plugin` helper.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,7 @@
 import partial from './partial';
 import inject from './inject';
 import tap from './tap';
+import plugin from './plugin';
 
-export {partial, inject, tap};
+export {partial, inject, tap, plugin};
 export default partial;

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -1,0 +1,18 @@
+import curry from 'lodash/curry';
+
+/**
+ * Add a plugin to a webpack configuration.
+ * @param {Object} plugin Plugin to add to the webpack configuration.
+ * @param {Object} config Webpack configuration.
+ * @returns {Object} New webpack configuration with the plugin added.
+ */
+export default curry((options, config) => {
+  const {plugins = []} = config;
+  return {
+    ...config,
+    plugins: [
+      ...plugins,
+      options,
+    ],
+  };
+});

--- a/test/spec/plugin.spec.js
+++ b/test/spec/plugin.spec.js
@@ -1,0 +1,10 @@
+import {expect} from 'chai';
+import plugin from '../../lib/plugin';
+
+describe('plugin', () => {
+  it('should add a plugin to the config', () => {
+    const conf = {plugins: []};
+    expect(plugin({}, conf)).to.have.property('plugins')
+      .to.have.length(1);
+  });
+});


### PR DESCRIPTION
Keeping in line with helping users quickly modify their webpack configurations, the `plugin` helper allows for easily adding a plugin to your webpack configuration. Again, the typical use is expected to be with `compose`.

```javascript
const newConfig = compose(
  plugin(new PluginA()),
  plugin(new PluginB())
)(webpackConfig);
```

/cc @baer @nealgranger 