### PR TITLE
Add `output` helper.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -2,6 +2,7 @@ import partial from './partial';
 import inject from './inject';
 import tap from './tap';
 import plugin from './plugin';
+import output from './output';
 
-export {partial, inject, tap, plugin};
+export {partial, inject, tap, plugin, output};
 export default partial;

--- a/lib/output.js
+++ b/lib/output.js
@@ -1,0 +1,11 @@
+import curry from 'lodash/curry';
+
+export default curry((output, config) => {
+  return {
+    ...config,
+    output: {
+      ...config.output,
+      ...output,
+    },
+  };
+});

--- a/test/spec/output.spec.js
+++ b/test/spec/output.spec.js
@@ -1,0 +1,11 @@
+import {expect} from 'chai';
+import output from '../../lib/output';
+
+describe('output', () => {
+  it('should update `output` in the config', () => {
+    const conf = {output: {foo: 'a', bar: 'b'}};
+    const result = output({foo: 'x', baz: 'y'}, conf);
+    expect(result).to.have.property('output').to.have.property('foo', 'x');
+    expect(result).to.have.property('output').to.have.property('baz', 'y');
+  });
+});


### PR DESCRIPTION
Useful for injecting `output` properties into webpack configurations. Useful with `compose`.

```javascript
const newConfig = compose(
  output({publicPath: '/'}),
  plugin(new Plugin())
)(oldConfig);
```

/cc @baer @nealgranger 