### PR TITLE
Add new `loader` function.

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,10 +44,25 @@ const config = plugin(new StatsWebpackPlugin(), {/* webpack config here */});
 
 The available helpers are:
 
+ * loader
  * merge
  * output
  * plugin
  * tap
+
+### loader(loader, config)
+
+Add a loader configuration to an existing webpack configuration.
+
+```javascript
+import loader from 'webpack-partial/loader';
+
+const babel = loader({
+  test: /\.js$/,
+  loader: 'babel-loader',
+})
+babel(webpackConfig);
+```
 
 ### merge(source, target)
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -4,6 +4,7 @@ import tap from './tap';
 import plugin from './plugin';
 import output from './output';
 import merge from './merge';
+import loader from './loader';
 
-export {partial, inject, tap, plugin, output, merge};
+export {partial, inject, tap, plugin, output, merge, loader};
 export default partial;

--- a/lib/loader.js
+++ b/lib/loader.js
@@ -1,0 +1,29 @@
+import curry from 'lodash/curry';
+import findIndex from 'lodash/findIndex';
+
+export default curry((loader, config) => {
+  const loaders = config.module && config.module.loaders ?
+    config.module.loaders.slice() : [];
+
+  if (loader.name) {
+    const index = findIndex(loaders, {name: loader.name});
+    if (index === -1) {
+      loaders.push(loader);
+    } else {
+      loaders[index] = {
+        ...loaders[index],
+        ...loader,
+      };
+    }
+  } else {
+    loaders.push(loader);
+  }
+
+  return {
+    ...config,
+    module: {
+      ...(config.module ? config.module : {}),
+      loaders,
+    },
+  };
+});

--- a/test/spec/loader.spec.js
+++ b/test/spec/loader.spec.js
@@ -1,0 +1,51 @@
+import {expect} from 'chai';
+import loader from '../../lib/loader';
+
+describe('loader', () => {
+  it('should handle empty configs', () => {
+    expect(loader({test: /foo/}, {}))
+      .to.have.property('module')
+      .to.have.property('loaders')
+      .to.have.length(1);
+  });
+
+  it('should handle empty module options', () => {
+    expect(loader({test: /foo/}, {module: {}}))
+      .to.have.property('module')
+      .to.have.property('loaders')
+      .to.have.length(1);
+  });
+
+  it('should append by default', () => {
+    expect(loader({test: /foo/}, {module: {loaders: [1]}}))
+      .to.have.property('module')
+      .to.have.property('loaders')
+      .to.have.length(2);
+  });
+
+  it('should merged duplicate named loaders', () => {
+    const result = loader(
+      {name: 'x', color: 'green'},
+      {module: {loaders: [{name: 'x', test: 'bar', color: 'red'}]}}
+    );
+
+    expect(result)
+      .to.have.property('module')
+      .to.have.property('loaders')
+      .to.have.length(1);
+    expect(result.module.loaders[0]).to.have.property('test', 'bar');
+    expect(result.module.loaders[0]).to.have.property('color', 'green');
+  });
+
+  it('should not merged non-duplicate named loaders', () => {
+    const result = loader(
+      {name: 'y', color: 'green'},
+      {module: {loaders: [{name: 'x', test: 'bar', color: 'red'}]}}
+    );
+
+    expect(result)
+      .to.have.property('module')
+      .to.have.property('loaders')
+      .to.have.length(2);
+  });
+});


### PR DESCRIPTION
Allows one to easily add a loader configuration to an existing webpack configuration. This is a more clean, specific case of `partial`.

/cc @nealgranger @baer 