### PR TITLE
Add `alias` helper.

### DIFF
--- a/lib/alias.js
+++ b/lib/alias.js
@@ -1,0 +1,6 @@
+import curry from 'lodash/curry';
+import set from 'lodash/fp/set';
+
+export default curry((src, target, config) =>
+  set(['resolve', 'alias', src], target, config)
+);

--- a/lib/index.js
+++ b/lib/index.js
@@ -5,6 +5,7 @@ import plugin from './plugin';
 import output from './output';
 import merge from './merge';
 import loader from './loader';
+import alias from './alias';
 
-export {partial, inject, tap, plugin, output, merge, loader};
+export {alias, partial, inject, tap, plugin, output, merge, loader};
 export default partial;

--- a/test/spec/alias.spec.js
+++ b/test/spec/alias.spec.js
@@ -1,0 +1,25 @@
+import {expect} from 'chai';
+import alias from '../../lib/alias';
+
+describe('alias', () => {
+  it('should handle empty configs', () => {
+    expect(alias('foo', 'bar', {}))
+      .to.have.property('resolve')
+      .to.have.property('alias')
+      .to.have.property('foo', 'bar');
+  });
+
+  it('should handle empty resolve options', () => {
+    expect(alias('foo', 'bar', {resolve: {}}))
+      .to.have.property('resolve')
+      .to.have.property('alias')
+      .to.have.property('foo', 'bar');
+  });
+
+  it('should overwrite by default', () => {
+    expect(alias('foo', 'baz', {resolve: {alias: {foo: 'bar'}}}))
+      .to.have.property('resolve')
+      .to.have.property('alias')
+      .to.have.property('foo', 'baz');
+  });
+});


### PR DESCRIPTION
This allows you to add `resolve.alias` entries easily to your webpack configuration.

For example:

```javascript
compose(
  alias('foo', 'bar'),
  alias('baz', 'qux')
);
```

Will generate:

```javascript
{
  resolve: {
    alias: {
      foo: 'bar',
      baz: 'qux',
    }
  }
}
```

/cc @nealgranger @baer 