### PR TITLE
Add `root` helper.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -6,6 +6,7 @@ import output from './output';
 import merge from './merge';
 import loader from './loader';
 import alias from './alias';
+import root from './root';
 
-export {alias, partial, inject, tap, plugin, output, merge, loader};
+export {alias, root, partial, inject, tap, plugin, output, merge, loader};
 export default partial;

--- a/lib/root.js
+++ b/lib/root.js
@@ -1,0 +1,15 @@
+import curry from 'lodash/curry';
+import update from 'lodash/fp/update';
+import path from 'path';
+
+export default curry((root, config) =>
+  update(['resolve', 'root'], (existing) => {
+    const x = root.charAt(0) === '/' ? root : path.join(config.context, root);
+    if (Array.isArray(existing)) {
+      return [...existing, x];
+    } else if (existing) {
+      return [existing, x];
+    }
+    return [x];
+  }, config)
+);

--- a/test/spec/root.spec.js
+++ b/test/spec/root.spec.js
@@ -1,0 +1,41 @@
+import {expect} from 'chai';
+import root from '../../lib/root';
+
+describe('alias', () => {
+  it('should handle empty configs', () => {
+    expect(root('/foo', {}))
+      .to.have.property('resolve')
+      .to.have.property('root')
+      .to.contain('/foo');
+  });
+
+  it('should handle empty resolve options', () => {
+    expect(root('/foo', {resolve: {}}))
+      .to.have.property('resolve')
+      .to.have.property('root')
+      .to.contain('/foo');
+  });
+
+  it('should join relative paths', () => {
+    expect(root('foo', {context: '/baz'}))
+      .to.have.property('resolve')
+      .to.have.property('root')
+      .to.contain('/baz/foo');
+  });
+
+  it('should append to single values', () => {
+    expect(root('/foo', {resolve: {root: '/bar'}}))
+      .to.have.property('resolve')
+      .to.have.property('root')
+      .to.contain('/foo')
+      .to.contain('/bar');
+  });
+
+  it('should append to arrays', () => {
+    expect(root('/foo', {resolve: {root: ['/bar']}}))
+      .to.have.property('resolve')
+      .to.have.property('root')
+      .to.contain('/foo')
+      .to.contain('/bar');
+  });
+});


### PR DESCRIPTION
Control the value of `resolve.root` easily. This supersedes https://github.com/webpack-config/webpack-config-root.

Using:

```javascript
compose(
  root('foo'),
  root('bar')
);
```

Results in:

```javascript
{
  resolve: {
    root: [
      'foo',
      'bar',
    ],
  },
}
```

/cc @nealgranger @baer 