### PR TITLE
Add `webpack@1` compatibility for `enforce: 'pre'`.

### DIFF
--- a/lib/loader.js
+++ b/lib/loader.js
@@ -1,7 +1,18 @@
 import curry from 'lodash/curry';
 import findIndex from 'lodash/findIndex';
+import update from 'lodash/fp/update';
+import flow from 'lodash/fp/flow';
 
-let verify = () => {};
+export const __config = {isWebpack2: false};
+
+let verify = (x) => x;
+
+try {
+  const pkg = require('webpack/package.json');
+  __config.isWebpack2 = /^2\./.exec(pkg.version);
+} catch (err) /* adana: +ignore */ {
+  // No webpack2 so RIP.
+}
 
 try {
   // Use webpack2 to automatically verify loaders when possible. This allows
@@ -17,23 +28,23 @@ try {
     if (errors.length) {
       throw new Err(errors);
     }
+    return loader;
   };
 } catch (err) /* adana: +ignore */ {
   // No webpack2 so RIP.
 }
 
-export default curry((loader, config) => {
-  const loaders = config.module && config.module.loaders ?
-    config.module.loaders.slice() : [];
+const path = (loader) => {
+  if (__config.isWebpack2) {
+    return ['module', 'loaders'];
+  }
+  if (loader.enforce === 'pre') {
+    return ['module', 'preLoaders'];
+  }
+  return ['module', 'loaders'];
+}
 
-  verify(loader);
-  loaders.push(loader);
-
-  return {
-    ...config,
-    module: {
-      ...(config.module ? config.module : {}),
-      loaders,
-    },
-  };
-});
+export default curry((loader, config) => update(path(loader), (all = []) => ([
+  ...all,
+  verify(loader),
+]), config));

--- a/test/spec/loader.spec.js
+++ b/test/spec/loader.spec.js
@@ -1,5 +1,5 @@
 import {expect} from 'chai';
-import loader from '../../lib/loader';
+import loader, {__config} from '../../lib/loader';
 
 describe('loader', () => {
   it('should handle empty configs', () => {
@@ -31,4 +31,29 @@ describe('loader', () => {
       )
     }).to.throw(Error)
   });
+
+  describe('webpack@1', () => {
+    beforeEach(() => {
+      __config.isWebpack2 = false;
+    });
+    afterEach(() => {
+      __config.isWebpack2 = true;
+    });
+
+    it('should use `preLoaders` when `enforce` is `pre`', () => {
+      expect(loader({test: /foo/, enforce: 'pre'}, {}))
+        .to.have.property('module')
+        .to.have.property('preLoaders')
+        .to.have.length(1);
+    });
+
+    it('should use `loaders` when no enforcement present', () => {
+      expect(loader({test: /foo/}, {}))
+        .to.have.property('module')
+        .to.have.property('loaders')
+        .to.have.length(1);
+    });
+  });
+
+
 });


### PR DESCRIPTION
This lets you use `loader({enforce: 'pre'})` in a `webpack@1` environment with no changes.

/cc @nealgranger @baer 