### PR TITLE
Automatically pack `loaders` for `webpack@1`.

### DIFF
--- a/lib/loader.js
+++ b/lib/loader.js
@@ -2,6 +2,7 @@ import curry from 'lodash/curry';
 import findIndex from 'lodash/findIndex';
 import update from 'lodash/fp/update';
 import flow from 'lodash/fp/flow';
+import isEqual from 'lodash/fp/isEqual';
 
 export const __config = {isWebpack2: false};
 
@@ -21,6 +22,9 @@ try {
   const validate = require('webpack/lib/validateWebpackOptions');
   const Err = require('webpack/lib/WebpackOptionsValidationError');
   verify = (loader) => {
+    if (!__config.isWebpack2) {
+      return loader;
+    }
     var errors = validate({
       entry: 'stub.js',
       module: {loaders: [loader]},
@@ -34,6 +38,33 @@ try {
   // No webpack2 so RIP.
 }
 
+const normalize = (loader) => {
+  if (__config.isWebpack2) {
+    return loader;
+  }
+  if (!loader.loaders || loader.loaders.length === 0) {
+    return loader;
+  }
+  return {
+    ...loader,
+    loaders: loader.loaders.map((entry) => {
+      if (typeof entry === 'string') {
+        return entry;
+      } else if (typeof entry === 'object') {
+        if (entry.query) {
+          const s = JSON.stringify(entry.query);
+          if (!isEqual(JSON.parse(s), entry.query)) {
+            throw new TypeError(`Invalid query as part of ${entry.loader}.`);
+          }
+          return `${entry.loader}?${s}`;
+        }
+        return entry.loader;
+      }
+      throw new TypeError();
+    }),
+  };
+};
+
 const path = (loader) => {
   if (__config.isWebpack2) {
     return ['module', 'loaders'];
@@ -46,5 +77,5 @@ const path = (loader) => {
 
 export default curry((loader, config) => update(path(loader), (all = []) => ([
   ...all,
-  verify(loader),
+  normalize(verify(loader)),
 ]), config));

--- a/test/spec/loader.spec.js
+++ b/test/spec/loader.spec.js
@@ -53,6 +53,40 @@ describe('loader', () => {
         .to.have.property('loaders')
         .to.have.length(1);
     });
+
+    it('should turn `loader` with multiple `loaders` into strings', () => {
+      const result = loader({
+        test: /foo/,
+        loaders: [
+          'a',
+          {loader: 'foo'},
+          {loader: 'bar', query: {message: 'hello'}}
+        ],
+      }, {});
+      const entry = result.module.loaders[0].loaders;
+      expect(entry).to.have.length(3);
+      expect(entry).to.have.property(0).to.equal('a');
+      expect(entry).to.have.property(1).to.equal('foo');
+      expect(entry).to.have.property(2).to.equal('bar?{"message":"hello"}');
+    });
+
+    it('should fail serializing functions', () => {
+      expect(() => {
+        loader(
+          {loaders:[{loader: 'a', query: {x: () => {}}}]},
+          {}
+        )
+      }).to.throw(TypeError);
+    });
+
+    it('should fail on garbage in loaders', () => {
+      expect(() => {
+        loader(
+          {loaders:[5]},
+          {}
+        )
+      }).to.throw(TypeError);
+    });
   });
 
 


### PR DESCRIPTION
With `webpack@2` you can specify both `loader` and `query` in the `loaders` array; in `webpack@1` you can only specify strings. This essentially polyfills that behaviour and avoids the need to write your own packing function. Note that you _cannot_ pass functions or other unserializable things through this; a guard has been put in place to catch this case.

/cc @nealgranger @baer 